### PR TITLE
Display hostname instead of short version

### DIFF
--- a/source/tools/hostname.sh
+++ b/source/tools/hostname.sh
@@ -4,9 +4,6 @@ function get_hostname
 {
     declare -n _hostname="$1"
 
-    _hostname="$(host -TtA "$(hostname -s)"|grep "has address"|awk '{ print $1 }')"
-    if [[ "$_hostname" = "" ]]
-    then
-        _hostname="$(hostname -s)"
-    fi
+    _hostname="$(hostname)"
 }
+


### PR DESCRIPTION
The previous command `host -TtA "$(hostname -s)"` were taking too long.
Moreover, using the short version of the hostname may not be enough on
some cases so roll back to the classic output of the `hostname` method.