### PR TITLE
Use compgen instead of set to check for var existence

### DIFF
--- a/source/tools/resolve_option_with_env.sh
+++ b/source/tools/resolve_option_with_env.sh
@@ -5,7 +5,7 @@ function resolve_option_with_env
     declare -n _ref="$1"
     declare -r environment_variable_name="$2"
 
-    if ( set -o posix ; set ) | grep -E -q "^$environment_variable_name="
+    if compgen -A variable ${environment_variable_name} &>/dev/null
     then
         _ref="${!environment_variable_name}"
     fi


### PR DESCRIPTION
Sometimes, when running a command, the script stops and warn us about
a variable that does not exists.
But if we run the exact same command again, it works just fine.

This is due to the fact that the `set` bash builtin command seems to
be unreliable.
For instance, if you run the following script several times, you will
notice that:
* NOT FOUND is printed
* the number of NOT FOUND printed is not the same between two run.

```
set -o pipefail

declare -g foo="bar"
for ((i=0; i<1000; i++))
do
    if ! (set -o posix; set) | grep -E -q "^foo="
    then
        echo "NOT FOUND"
    fi
done
```

This is probably due to the mixed usage of `set -o pipefail` and
the `(set -o posix; set)` that might not print all variables.

A better way to check for variable existence is to use `compgen`
bash builtin command.